### PR TITLE
Update site name and generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>스쿨플랜 AI</title>
+    <title>에이두 티쳐 AI</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -32,7 +32,7 @@
         <!-- Auth View (Login/Signup) -->
         <div id="auth-view" class="min-h-screen flex items-center justify-center bg-gray-100">
             <div class="w-full max-w-md bg-white rounded-lg shadow-md p-8">
-                <h2 class="text-2xl font-bold text-center text-[#7A9D54] mb-6">스쿨플랜 AI 시작하기</h2>
+                <h2 class="text-2xl font-bold text-center text-[#7A9D54] mb-6">에이두 티쳐 AI 시작하기</h2>
                 <form id="auth-form" onsubmit="return false;">
                     <div class="mb-4">
                         <label for="email" class="block text-gray-700 text-sm font-bold mb-2">이메일</label>
@@ -64,7 +64,7 @@
         <div id="main-app-view" class="hidden flex-col min-h-screen">
             <header class="bg-white shadow-md w-full sticky top-0 z-50">
                 <div class="container mx-auto px-6 py-3 flex justify-between items-center">
-                    <h1 class="text-2xl font-bold text-[#7A9D54]">📝 스쿨플랜 AI</h1>
+                    <h1 class="text-2xl font-bold text-[#7A9D54]">📝 에이두 티쳐 AI</h1>
                     <nav class="flex items-center gap-4">
                         <span id="user-email" class="text-sm text-gray-600"></span>
                         <a href="#dashboard" id="nav-dashboard" class="nav-link">대시보드</a>
@@ -80,7 +80,7 @@
                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                         <div class="lg:col-span-2 bg-white p-6 rounded-lg shadow-lg">
                             <h3 class="text-xl font-bold mb-2">안녕하세요, <span id="dashboard-user-email"></span> 선생님!</h3>
-                            <p class="text-gray-600 mb-4">스쿨플랜 AI와 함께라면 학교 운영계획서 작성이 쉬워집니다.</p>
+                            <p class="text-gray-600 mb-4">에이두 티쳐 AI와 함께라면 학교 운영계획서 작성이 쉬워집니다.</p>
                             <button id="go-to-generator-btn" class="bg-[#7A9D54] text-white font-bold py-3 px-6 rounded-lg hover:bg-[#6a8a4a] transition-colors">새 운영계획서 만들기 →</button>
                         </div>
                         <div class="bg-white p-6 rounded-lg shadow-lg">
@@ -117,6 +117,7 @@
                                     <label for="keywords" class="block text-sm font-medium text-gray-700">핵심 키워드 (선택)</label>
                                     <input type="text" id="keywords" placeholder="예: 메타버스, AI 융합, 학생 주도" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-green-500 sm:text-sm">
                                 </div>
+                                <div class="flex items-center"><input type="checkbox" id="include-budget" class="mr-2"><label for="include-budget" class="text-sm font-medium text-gray-700">예산 포함</label></div>
                                 <p id="form-error" class="text-red-500 text-xs italic mt-2 hidden"></p>
                                 <button type="submit" id="generate-btn" class="w-full bg-[#7A9D54] text-white font-bold py-3 px-4 rounded-lg hover:bg-[#6a8a4a] flex items-center justify-center">AI 운영계획서 생성</button>
                             </form>
@@ -196,6 +197,7 @@
         const formError = document.getElementById('form-error');
         
         let statsChartInstance = null;
+        const includeBudgetCheckbox = document.getElementById('include-budget');
 
         // --- AUTHENTICATION ---
         onAuthStateChanged(auth, user => {
@@ -465,7 +467,13 @@
             generateBtn.innerHTML = `<div class="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"></div><span class="ml-2">생성 중...</span>`;
 
             try {
-                const prompt = `당신은 대한민국의 유능한 교사입니다. 다음 조건에 맞춰 '${schoolLevelSelect.value} ${planType}' 초안을 작성해 주세요. 핵심 키워드는 '${document.getElementById('keywords').value || '없음'}' 입니다. 출력 형식은 TITLE: [제목], ### [섹션 제목], 그리고 Markdown 테이블 형식의 세부 계획을 반드시 포함해야 합니다.`;
+                const keywords = document.getElementById('keywords').value || '없음';
+                const includeBudget = includeBudgetCheckbox.checked;
+                let prompt = `당신은 대한민국의 유능한 교사입니다. '${schoolLevelSelect.value} ${planType}' 운영 계획을 작성해 주세요. 핵심 키워드는 '${keywords}' 입니다.`;
+                if (planType === '초등학교 교육과정 운영계획') {
+                    prompt += `\n목적 예시:\n◦ 미래 역량 함양 가능한 교육과정 구현으로 포용성과 창의성을 갖춘 자기주도적 미래인재 양성\n◦ 교육과정 편성·운영 지원으로 2022 개정 교육과정 현장 안착\n◦ 학습자의 삶과 성장을 지원하는 맞춤형 교육과정 설계 및 운영\n◦ 자유학기제 수업 및 평가 개선을 통한 공교육 만족도 제고\n◦ 교과 보충 맞춤형 학습 지원으로 자기주도적 학습 능력 향상\n운영 방침 예시:\n◦ 학교 여건 및 교육공동체의 요구와 필요를 반영한 자율적인 학교교육과정 편성·운영\n◦ 교육과정·자유학기제 현장지원단 운영으로 안정적 현장 지원\n◦ 자료집 개발 및 연수·컨설팅으로 교육공동체 성장 맞춤형 설계 역량 강화\n◦ 학교자율시간 활용 인정도서 개발로 다양한 교육과정 설계 및 질 관리 강화\n◦ 탐구 활동 중심의 수업 및 평가 피드백 강화로 자유학기제 내실화\n◦ 맞춤형 학습 지원을 강화하는 학습사다리교실 운영\n기대효과 예시:\n◦ 학교 교육과정 설계‧운영 지원 역량 함양을 통한 2022 개정 교육과정의 안정적 도입 기반 구축\n◦ 학교 여건과 지역 특색 및 교육과정의 취지를 살릴 수 있는 학교 교육과정 설계‧운영으로 학교의 자율 역량 강화\n◦ 학생 스스로 학습과 진로를 설계하는 자기주도적 미래 인재 양성`;
+                }
+                prompt += ` 출력 형식은 TITLE: [제목], ### 목적, ### 운영방침, ### 세부 운영 계획${includeBudget ? ', ### 예산(표로 작성)' : ''}, ### 기대효과 순으로 작성하세요.`;
                 const geminiApiKey = "AIzaSyC7_Gq4LIVVMv0hMD6qSwcTlGJcDSt-KgI";
                 const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${geminiApiKey}`;
                 const response = await fetch(apiUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] }) });
@@ -533,20 +541,26 @@
             return title;
         }
         
-        copyBtn.addEventListener('click', () => {
-            const textToCopy = generatedContentDiv.innerText;
-            const textArea = document.createElement('textarea');
-            textArea.value = textToCopy;
-            document.body.appendChild(textArea);
-            textArea.select();
+        copyBtn.addEventListener('click', async () => {
+            const htmlContent = generatedContentDiv.innerHTML;
             try {
-                document.execCommand('copy');
+                if (navigator.clipboard && window.ClipboardItem) {
+                    await navigator.clipboard.write([
+                        new ClipboardItem({ 'text/html': new Blob([htmlContent], { type: 'text/html' }) })
+                    ]);
+                } else {
+                    const textArea = document.createElement('textarea');
+                    textArea.value = htmlContent;
+                    document.body.appendChild(textArea);
+                    textArea.select();
+                    document.execCommand('copy');
+                    document.body.removeChild(textArea);
+                }
                 copyBtn.textContent = '복사 완료!';
             } catch (err) {
                 console.error('클립보드 복사 실패:', err);
                 copyBtn.textContent = '복사 실패';
             }
-            document.body.removeChild(textArea);
             setTimeout(() => { copyBtn.textContent = '본문 복사'; }, 2000);
         });
 


### PR DESCRIPTION
## Summary
- rename site to **에이두 티쳐**
- add 예산 포함 checkbox when generating plans
- adjust prompt rules and preset examples for 초등학교 교육과정 운영계획
- copy generated content as HTML for easier pasting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a18ecf4d8832eb90532f7a9b702d8